### PR TITLE
Fixed the following issues in build 1.01.0010: (#183)

### DIFF
--- a/src/VSNDK.AddIn/VSNDKAddIn.cs
+++ b/src/VSNDK.AddIn/VSNDKAddIn.cs
@@ -59,6 +59,7 @@ namespace VSNDK.AddIn
         public int amountOfProjects = 0;
         public bool hitPlay = false; // used to know if user has clicked in the play button
         public bool isDeploying = false;
+        private string targetDir = ""; // used to store the target directory in ProcessesPath.txt file, that will be used later in "attach to process"
 
         private const string BLACKBERRY = "BlackBerry";
         private const string BLACKBERRYSIMULATOR = "BlackBerrySimulator";
@@ -412,6 +413,7 @@ namespace VSNDK.AddIn
                             if (p1.UniqueName == startupProject)
                             {
                                 buildThese.Add(p1.FullName);
+                                targetDir = p1.FullName.Remove(p1.FullName.LastIndexOf('\\') + 1);
                                 break;
                             }
                         }
@@ -586,12 +588,15 @@ namespace VSNDK.AddIn
                     }
 
                     // Updating the contents.
-                    int begin = outputText.IndexOf("Project: ") + 9;
+                    int begin = outputText.IndexOf("Deploy started: Project: ") + 25;
+                    if (begin == -1)
+                        begin = outputText.IndexOf("Project: ") + 9;
                     int end = outputText.IndexOf(", Configuration:", begin);
                     string processName = outputText.Substring(begin, end - begin);
                     begin = processesPaths.IndexOf(processName + ":>");
 
-                    string currentPath = dte.ActiveDocument.Path;
+//                    string currentPath = dte.ActiveDocument.Path;
+                    string currentPath = targetDir;
 
                     if (begin != -1)
                     {

--- a/src/VSNDK.DebugEngine/AD7.Impl/AD7BoundBreakpoint.cs
+++ b/src/VSNDK.DebugEngine/AD7.Impl/AD7BoundBreakpoint.cs
@@ -201,7 +201,8 @@ namespace VSNDK.DebugEngine
                 m_remoteID = m_engine.BPMgr.RemoteAdd(this);
             }
 
-            if ((m_remoteID == 0) && (VSNDK.AddIn.VSNDKAddIn.isDebugEngineRunning == false))
+//            if ((m_remoteID == 0) && (VSNDK.AddIn.VSNDKAddIn.isDebugEngineRunning == false))
+            if (m_remoteID == 0)
             {
                 return;
             }

--- a/src/VSNDK.DebugEngine/AD7.Impl/AD7Engine.cs
+++ b/src/VSNDK.DebugEngine/AD7.Impl/AD7Engine.cs
@@ -26,6 +26,7 @@ using VSNDK.AddIn;
 using NameValueCollection = System.Collections.Specialized.NameValueCollection;
 using NameValueCollectionHelper = VSNDK.AddIn.NameValueCollectionHelper;
 using System.Collections;
+using System.Windows.Forms;
 
 namespace VSNDK.DebugEngine
 {
@@ -268,12 +269,18 @@ namespace VSNDK.DebugEngine
                         }
                     }
                     else
+                    {
                         exePath = "CannotAttachToRunningProcess";
+                    }
 
                     exePath = exePath.Replace("\\", "\\\\\\\\");
 
                     if (GDBParser.LaunchProcess(pnt.m_programID, exePath, port.m_IP, port.m_isSimulator, port.m_toolsPath, publicKeyPath, port.m_password))
                     {
+                        if (exePath == "CannotAttachToRunningProcess")
+                        {
+                            MessageBox.Show(progName + " is attached to the debugger. However, to be able to debug your application, you must build and deploy it from this computer first.", "No executable file with symbols found.", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                        }
                         m_eventDispatcher = new EventDispatcher(this);
                         m_module = new AD7Module();
                         m_progNode = new AD7ProgramNode(m_process._processGUID, m_process._processID, exePath, new Guid(AD7Engine.Id));

--- a/src/VSNDK.DebugEngine/AD7.Impl/AD7PendingBreakpoint.cs
+++ b/src/VSNDK.DebugEngine/AD7.Impl/AD7PendingBreakpoint.cs
@@ -176,7 +176,7 @@ namespace VSNDK.DebugEngine
                         return VSConstants.S_FALSE;
                     }
 
-                    if (xBBP == null)
+                    if ((xBBP == null) || (xBBP.GDB_ID == 0))
                     {
                         return VSConstants.S_FALSE;
                     }

--- a/src/VSNDK.DebugEngine/Engine.Impl/BreakpointManager.cs
+++ b/src/VSNDK.DebugEngine/Engine.Impl/BreakpointManager.cs
@@ -102,9 +102,6 @@ namespace VSNDK.DebugEngine
         /// <returns> Breakpoint ID Number. </returns>
         public int RemoteAdd(AD7BoundBreakpoint aBBP)
         {
-
-            m_activeBPs.Add(aBBP);
-
             // Call GDB to set a breakpoint based on filename and line no. in aBBP                                                           
             uint GDB_ID = 0;
             uint GDB_LinePos = 0;
@@ -123,6 +120,8 @@ namespace VSNDK.DebugEngine
 
             if (ret)
             {
+                m_activeBPs.Add(aBBP);
+
                 aBBP.GDB_ID = GDB_ID;
                 aBBP.GDB_FileName = GDB_Filename;
                 aBBP.GDB_LinePos = GDB_LinePos;

--- a/src/VSNDK.DebugEngine/Engine.Impl/EventDispatcher.cs
+++ b/src/VSNDK.DebugEngine/Engine.Impl/EventDispatcher.cs
@@ -294,8 +294,9 @@ namespace VSNDK.DebugEngine
                 // (http://sourceware.org/gdb/onlinedocs/gdb/GDB_002fMI-Breakpoint-Commands.html)
                 response = GDBParser.parseCommand(command, 6);
 
-                if ((response.Length < 2) && (VSNDK.AddIn.VSNDKAddIn.isDebugEngineRunning == false))
+                if (((response.Length < 2) && (VSNDK.AddIn.VSNDKAddIn.isDebugEngineRunning == false)) || (response == "Function not found!"))
                 {
+                    resumeFromInterrupt();
                     return false;
                 }
 

--- a/src/VSNDK.Tasks/GenerateMakefile.cs
+++ b/src/VSNDK.Tasks/GenerateMakefile.cs
@@ -501,15 +501,18 @@ namespace VSNDK.Tasks
         /// <returns></returns>
         private bool isExcludedPath(string path)
         {
-            foreach (string exDir in ExcludeDirectories)
+            if (ExcludeDirectories != null)
             {
-                if (Path.GetFullPath(path).Contains(Path.GetFullPath(exDir)))
+                foreach (string exDir in ExcludeDirectories)
                 {
-                    return true;
-                }
-                else
-                {
-                    return false;
+                    if (Path.GetFullPath(path).Contains(Path.GetFullPath(exDir)))
+                    {
+                        return true;
+                    }
+/*                    else
+                    {
+                        return false;
+                    }*/
                 }
             }
             return false;


### PR DESCRIPTION
- updated ProcessesPaths.txt file with the correct project path name;
- handled function breakpoints with wrong names;
- allowed projects that does not have "Excluded directories";
- let the user know if the attached app does not have an associated executable file with symbols.
