### PR TITLE
Fixed issue #376 in VS 2012 (it was already fixed for VS 2010 in build 1...

### DIFF
--- a/src_vs2012/VSNDK.Package/Signing/Models/RegistrationData.cs
+++ b/src_vs2012/VSNDK.Package/Signing/Models/RegistrationData.cs
@@ -251,7 +251,7 @@ namespace RIM.VSNDK_Package.Signing.Models
             string err = this[_colAuthor];
             if (!string.IsNullOrEmpty(err))
                 _errors += err + "\n";
-            if (this.Author.ToUpper() == "BLACKBERRY")
+            if (this.Author.Trim().ToUpper() == "BLACKBERRY")
                 _errors += "BlackBerry is a reserved word and can not be used as \"author name\".\n"; 
             err = this[_colCSJPW];
             if (!string.IsNullOrEmpty(err))


### PR DESCRIPTION
....01.0028)
#376 - Signing Registration Window allows BlackBerry with trailing spaces to be inputted as Author
