### PR TITLE
Fixed issues #373, #374, #377 and #383, for both VS 2010 and 2012

### DIFF
--- a/src/VSNDK.Package/DebugToken/DebugTokenDialog.xaml.cs
+++ b/src/VSNDK.Package/DebugToken/DebugTokenDialog.xaml.cs
@@ -87,7 +87,7 @@ namespace RIM.VSNDK_Package.DebugToken
             {
                 this.Cursor = Cursors.Wait;
 
-                if (!(deployTokenData.addDevice()))
+                if (!(deployTokenData.addDevice(this)))
                 {
                     deployTokenData.Error = "";
                     e.Handled = true;
@@ -104,8 +104,8 @@ namespace RIM.VSNDK_Package.DebugToken
             {
                 this.Cursor = Cursors.Arrow;
             }
-            
         }
+
 
         /// <summary>
         /// Refresh debug token to device and registration file.
@@ -116,7 +116,7 @@ namespace RIM.VSNDK_Package.DebugToken
         {
             this.Cursor = Cursors.Wait;
 
-            if (!(deployTokenData.refreshDevice()))
+            if (!(deployTokenData.refreshDevice(this)))
             {
                 deployTokenData.Error = "";
                 e.Handled = true;

--- a/src/VSNDK.Package/DebugToken/Model/DebugTokenData.cs
+++ b/src/VSNDK.Package/DebugToken/Model/DebugTokenData.cs
@@ -58,6 +58,7 @@ namespace RIM.VSNDK_Package.DebugToken.Model
         private const string _colAuthorID = "AuthorID";
         private const string _colAttachedDevice = "AttachedDevice";
         private const string _colExpiryDate = "ExpiryDate";
+        public static bool restart = false;
 
         #endregion
 
@@ -309,7 +310,6 @@ namespace RIM.VSNDK_Package.DebugToken.Model
                         isRegistered();
                     }
                 }
-
             }
             catch (Exception ex)
             {
@@ -324,7 +324,7 @@ namespace RIM.VSNDK_Package.DebugToken.Model
         /// <summary>
         /// Add current device to device list.
         /// </summary>
-        public bool addDevice()
+        public bool addDevice(DebugTokenDialog parent)
         {
             if (DevicePIN == "Not Attached")
             {
@@ -340,14 +340,16 @@ namespace RIM.VSNDK_Package.DebugToken.Model
 
             if (createDebugToken()) uploadDebugToken();
 
-            while ((_errors.Contains("invalid password")) || (_errors.Contains("password is not valid")) || (_errors.Contains("invalid store password")))
+            if ((_errors.Contains("invalid password")) || (_errors.Contains("password is not valid")) || (_errors.Contains("invalid store password")))
             {
                 MessageBox.Show("The specified password is invalid.\n\nPlease, enter the same one that you used to generate your BB ID Token.\n\nIf you don't remember it, you might close the next window, unregister and register again using BlackBerry -> Signing menu.",_errors, MessageBoxButtons.OK, MessageBoxIcon.Error);
 
-                if (!resetPassword())
-                    return false;
-
-                if (createDebugToken()) uploadDebugToken();
+                parent.Close();
+                if (resetPassword())
+                {
+                    restart = true;
+                }
+                return false;
             }
 
             if (_errors.Contains("Cannot connect:"))
@@ -370,7 +372,7 @@ namespace RIM.VSNDK_Package.DebugToken.Model
         /// <summary>
         /// Refresh current device to device list.
         /// </summary>
-        public bool refreshDevice()
+        public bool refreshDevice(DebugTokenDialog parent)
         {
             if (DevicePIN == "Not Attached")
             {
@@ -386,14 +388,16 @@ namespace RIM.VSNDK_Package.DebugToken.Model
 
             if (createDebugToken()) uploadDebugToken();
 
-            while ((_errors.Contains("invalid password")) || (_errors.Contains("password is not valid")) || (_errors.Contains("invalid store password")))
+            if ((_errors.Contains("invalid password")) || (_errors.Contains("password is not valid")) || (_errors.Contains("invalid store password")))
             {
-                MessageBox.Show("The specified password is invalid. Please, enter the same one that you used to generate your BB ID Token.\nIf you don't remember, you might close this window, unregister and register again.", _errors);
+                MessageBox.Show("The specified password is invalid.\n\nPlease, enter the same one that you used to generate your BB ID Token.\n\nIf you don't remember it, you might close the next window, unregister and register again using BlackBerry -> Signing menu.",_errors, MessageBoxButtons.OK, MessageBoxIcon.Error);
 
-                if (!resetPassword())
-                    return false;
-
-                if (createDebugToken()) uploadDebugToken();
+                parent.Close();
+                if (resetPassword())
+                {
+                    restart = true;
+                }
+                return false;
             }
 
             if (_errors.Contains("Cannot connect:"))

--- a/src/VSNDK.Package/Settings/Model/SettingsData.cs
+++ b/src/VSNDK.Package/Settings/Model/SettingsData.cs
@@ -74,6 +74,8 @@ namespace RIM.VSNDK_Package.Settings.Models
         /// </summary>
         public SettingsData()
         {
+            getDeviceInfo();
+            getSimulatorInfo();
             RefreshScreen();
         }
 

--- a/src/VSNDK.Package/Signing/Browser.Designer.cs
+++ b/src/VSNDK.Package/Signing/Browser.Designer.cs
@@ -80,6 +80,7 @@ namespace RIM.VSNDK_Package.Signing
         {
             if (e.Url.Segments[e.Url.Segments.Length - 1].EndsWith("csk.pg"))
             {
+                this.Cursor = Cursors.WaitCursor;
                 HttpWebRequest request = (HttpWebRequest)WebRequest.Create(e.Url);
                 request.Referer = ((WebBrowser)sender).Url.ToString();
                 request.CookieContainer = new CookieContainer();
@@ -119,7 +120,7 @@ namespace RIM.VSNDK_Package.Signing
                 {
                     MessageBox.Show("Server error, please, try again later.", "Server Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 }
-
+                this.Cursor = Cursors.Arrow;
                 this.Close();
             }
         }

--- a/src/VSNDK.Package/Signing/Models/RegistrationData.cs
+++ b/src/VSNDK.Package/Signing/Models/RegistrationData.cs
@@ -252,7 +252,7 @@ namespace RIM.VSNDK_Package.Signing.Models
             if (!string.IsNullOrEmpty(err))
                 _errors += err + "\n";
             if (this.Author.Trim().ToUpper() == "BLACKBERRY")
-                _errors += "BlackBerry is a reserved word and can not be used as \"author name\".\n";
+                _errors += "BlackBerry is a reserved word and cannot be used as \"author name\".\n";
             err = this[_colCSJPW];
             if (!string.IsNullOrEmpty(err))
                 _errors += err + "\n";

--- a/src/VSNDK.Package/VSNDK.PackagePackage.cs
+++ b/src/VSNDK.Package/VSNDK.PackagePackage.cs
@@ -70,7 +70,6 @@ namespace RIM.VSNDK_Package
     {
         private EnvDTE.DTE _dte;
 
-
         /// <summary>
         /// Default constructor of the package.
         /// Inside this method you can place any initialization code that does not require 
@@ -116,11 +115,18 @@ namespace RIM.VSNDK_Package
         /// </summary>
         private void ShowDebugTokenWindow(object sender, EventArgs e)
         {
-            // Create the dialog instance without Help support.
-            var DebugTokenDialog = new DebugToken.DebugTokenDialog();
-            // Show the dialog.
-            if (!DebugTokenDialog.IsClosing)
-                DebugTokenDialog.ShowModal();
+            do
+            {
+                // Create the dialog instance without Help support.
+                var DebugTokenDialog = new DebugToken.DebugTokenDialog();
+
+                DebugToken.Model.DebugTokenData.restart = false;
+
+                // Show the dialog.
+                if (!DebugTokenDialog.IsClosing)
+                    DebugTokenDialog.ShowModal();
+
+            } while (DebugToken.Model.DebugTokenData.restart);
         }
 
         private void MenuItemCallback(object sender, EventArgs e)

--- a/src_vs2012/VSNDK.Package/DebugToken/DebugTokenDialog.xaml.cs
+++ b/src_vs2012/VSNDK.Package/DebugToken/DebugTokenDialog.xaml.cs
@@ -87,7 +87,7 @@ namespace RIM.VSNDK_Package.DebugToken
             {
                 this.Cursor = Cursors.Wait;
 
-                if (!(deployTokenData.addDevice()))
+                if (!(deployTokenData.addDevice(this)))
                 {
                     deployTokenData.Error = "";
                     e.Handled = true;
@@ -104,8 +104,8 @@ namespace RIM.VSNDK_Package.DebugToken
             {
                 this.Cursor = Cursors.Arrow;
             }
-            
         }
+
 
         /// <summary>
         /// Refresh debug token to device and registration file.
@@ -116,7 +116,7 @@ namespace RIM.VSNDK_Package.DebugToken
         {
             this.Cursor = Cursors.Wait;
 
-            if (!(deployTokenData.refreshDevice()))
+            if (!(deployTokenData.refreshDevice(this)))
             {
                 deployTokenData.Error = "";
                 e.Handled = true;

--- a/src_vs2012/VSNDK.Package/DebugToken/Model/DebugTokenData.cs
+++ b/src_vs2012/VSNDK.Package/DebugToken/Model/DebugTokenData.cs
@@ -58,6 +58,7 @@ namespace RIM.VSNDK_Package.DebugToken.Model
         private const string _colAuthorID = "AuthorID";
         private const string _colAttachedDevice = "AttachedDevice";
         private const string _colExpiryDate = "ExpiryDate";
+        public static bool restart = false;
 
         #endregion
 
@@ -309,7 +310,6 @@ namespace RIM.VSNDK_Package.DebugToken.Model
                         isRegistered();
                     }
                 }
-
             }
             catch (Exception ex)
             {
@@ -324,7 +324,7 @@ namespace RIM.VSNDK_Package.DebugToken.Model
         /// <summary>
         /// Add current device to device list.
         /// </summary>
-        public bool addDevice()
+        public bool addDevice(DebugTokenDialog parent)
         {
             if (DevicePIN == "Not Attached")
             {
@@ -340,14 +340,16 @@ namespace RIM.VSNDK_Package.DebugToken.Model
 
             if (createDebugToken()) uploadDebugToken();
 
-            while ((_errors.Contains("invalid password")) || (_errors.Contains("password is not valid")) || (_errors.Contains("invalid store password")))
+            if ((_errors.Contains("invalid password")) || (_errors.Contains("password is not valid")) || (_errors.Contains("invalid store password")))
             {
-                MessageBox.Show("The specified password is invalid.\n\nPlease, enter the same one that you used to generate your BB ID Token.\n\nIf you don't remember it, you might close the next window, unregister and register again using BlackBerry -> Signing menu.",_errors, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show("The specified password is invalid.\n\nPlease, enter the same one that you used to generate your BB ID Token.\n\nIf you don't remember it, you might close the next window, unregister and register again using BlackBerry -> Signing menu.", _errors, MessageBoxButtons.OK, MessageBoxIcon.Error);
 
-                if (!resetPassword())
-                    return false;
-
-                if (createDebugToken()) uploadDebugToken();
+                parent.Close();
+                if (resetPassword())
+                {
+                    restart = true;
+                }
+                return false;
             }
 
             if (_errors.Contains("Cannot connect:"))
@@ -370,7 +372,7 @@ namespace RIM.VSNDK_Package.DebugToken.Model
         /// <summary>
         /// Refresh current device to device list.
         /// </summary>
-        public bool refreshDevice()
+        public bool refreshDevice(DebugTokenDialog parent)
         {
             if (DevicePIN == "Not Attached")
             {
@@ -386,14 +388,16 @@ namespace RIM.VSNDK_Package.DebugToken.Model
 
             if (createDebugToken()) uploadDebugToken();
 
-            while ((_errors.Contains("invalid password")) || (_errors.Contains("password is not valid")) || (_errors.Contains("invalid store password")))
+            if ((_errors.Contains("invalid password")) || (_errors.Contains("password is not valid")) || (_errors.Contains("invalid store password")))
             {
-                MessageBox.Show("The specified password is invalid. Please, enter the same one that you used to generate your BB ID Token.\nIf you don't remember, you might close this window, unregister and register again.", _errors);
+                MessageBox.Show("The specified password is invalid.\n\nPlease, enter the same one that you used to generate your BB ID Token.\n\nIf you don't remember it, you might close the next window, unregister and register again using BlackBerry -> Signing menu.", _errors, MessageBoxButtons.OK, MessageBoxIcon.Error);
 
-                if (!resetPassword())
-                    return false;
-
-                if (createDebugToken()) uploadDebugToken();
+                parent.Close();
+                if (resetPassword())
+                {
+                    restart = true;
+                }
+                return false;
             }
 
             if (_errors.Contains("Cannot connect:"))

--- a/src_vs2012/VSNDK.Package/Settings/Model/SettingsData.cs
+++ b/src_vs2012/VSNDK.Package/Settings/Model/SettingsData.cs
@@ -74,6 +74,8 @@ namespace RIM.VSNDK_Package.Settings.Models
         /// </summary>
         public SettingsData()
         {
+            getDeviceInfo();
+            getSimulatorInfo();
             RefreshScreen();
         }
 

--- a/src_vs2012/VSNDK.Package/Signing/Browser.Designer.cs
+++ b/src_vs2012/VSNDK.Package/Signing/Browser.Designer.cs
@@ -80,6 +80,7 @@ namespace RIM.VSNDK_Package.Signing
         {
             if (e.Url.Segments[e.Url.Segments.Length - 1].EndsWith("csk.pg"))
             {
+                this.Cursor = Cursors.WaitCursor;
                 HttpWebRequest request = (HttpWebRequest)WebRequest.Create(e.Url);
                 request.Referer = ((WebBrowser)sender).Url.ToString();
                 request.CookieContainer = new CookieContainer();
@@ -119,7 +120,7 @@ namespace RIM.VSNDK_Package.Signing
                 {
                     MessageBox.Show("Server error, please, try again later.", "Server Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 }
-
+                this.Cursor = Cursors.Arrow;
                 this.Close();
             }
         }

--- a/src_vs2012/VSNDK.Package/Signing/Models/RegistrationData.cs
+++ b/src_vs2012/VSNDK.Package/Signing/Models/RegistrationData.cs
@@ -252,7 +252,7 @@ namespace RIM.VSNDK_Package.Signing.Models
             if (!string.IsNullOrEmpty(err))
                 _errors += err + "\n";
             if (this.Author.Trim().ToUpper() == "BLACKBERRY")
-                _errors += "BlackBerry is a reserved word and can not be used as \"author name\".\n"; 
+                _errors += "BlackBerry is a reserved word and cannot be used as \"author name\".\n"; 
             err = this[_colCSJPW];
             if (!string.IsNullOrEmpty(err))
                _errors += err + "\n";

--- a/src_vs2012/VSNDK.Package/VSNDK.PackagePackage.cs
+++ b/src_vs2012/VSNDK.Package/VSNDK.PackagePackage.cs
@@ -70,7 +70,6 @@ namespace RIM.VSNDK_Package
     {
         private EnvDTE.DTE _dte;
 
-
         /// <summary>
         /// Default constructor of the package.
         /// Inside this method you can place any initialization code that does not require 
@@ -116,11 +115,18 @@ namespace RIM.VSNDK_Package
         /// </summary>
         private void ShowDebugTokenWindow(object sender, EventArgs e)
         {
-            // Create the dialog instance without Help support.
-            var DebugTokenDialog = new DebugToken.DebugTokenDialog();
-            // Show the dialog.
-            if (!DebugTokenDialog.IsClosing)
-                DebugTokenDialog.ShowModal();
+            do
+            {
+                // Create the dialog instance without Help support.
+                var DebugTokenDialog = new DebugToken.DebugTokenDialog();
+
+                DebugToken.Model.DebugTokenData.restart = false;
+
+                // Show the dialog.
+                if (!DebugTokenDialog.IsClosing)
+                    DebugTokenDialog.ShowModal();
+
+            } while (DebugToken.Model.DebugTokenData.restart);
         }
 
         private void MenuItemCallback(object sender, EventArgs e)


### PR DESCRIPTION
#373 - reauthorization of bb id token from debug token dialog looks unresponsive when correct authentication is provided.
#374 - user receives 2 different dialogs for notifying invalid bb token password if device doesn't have bb token or not.
#377 - Signing Registration Window author Blackbery error use cannot not can not.
#383 - BlackBerry Settings and Debug Token dialog boxes should both get the device IP from Registry.
