### PR TITLE
Fixed #400

### DIFF
--- a/src/VSNDK.Package/ViewModel.cs
+++ b/src/VSNDK.Package/ViewModel.cs
@@ -485,17 +485,26 @@ namespace RIM.VSNDK_Package
             return retVal;
         }
 
+        /// <summary>
+        /// Load the permissions list
+        /// </summary>
         private void LoadPermissions()
         {
             SettingsData settingsData = new SettingsData();
+            bool oldListMethod = true;
+            XmlNodeList pList = null;
 
-            XmlDocument xmlDoc = new XmlDocument();
-            xmlDoc.Load(settingsData.TargetPath + @"\..\blackberry-sdk-descriptor.xml");
-            XmlNodeList pList = xmlDoc.GetElementsByTagName("permission");
+            if (settingsData.TargetPath != "")
+            {
+                XmlDocument xmlDoc = new XmlDocument();
+                xmlDoc.Load(settingsData.TargetPath + @"\..\blackberry-sdk-descriptor.xml");
+                pList = xmlDoc.GetElementsByTagName("permission");
+                oldListMethod = false;
+            }
 
             IList<PermissionItemClass> PermissionList = new List<PermissionItemClass>();
 
-            if (pList.Count == 0) // Old Listing Method
+            if (oldListMethod) // Old Listing Method
             {
                 PermissionItemClass permissionItem = new PermissionItemClass(isPermissionChecked("bbm_connect"), "BlackBerry Messenger", "bbm_connect", getPermissionIcon("bbm_connect"));
                 PermissionList.Add(permissionItem);

--- a/src/VSNDK.Tasks/BlackBerry/PlatformToolsets/qcc/Microsoft.Cpp.BlackBerry.qcc.props
+++ b/src/VSNDK.Tasks/BlackBerry/PlatformToolsets/qcc/Microsoft.Cpp.BlackBerry.qcc.props
@@ -17,7 +17,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <PropertyGroup>
     <QNX_TARGET>$(Registry:HKEY_CURRENT_USER\SOFTWARE\BlackBerry\BlackBerryVSPlugin@NDKTargetPath)</QNX_TARGET>
     <QNX_HOST>$(Registry:HKEY_CURRENT_USER\SOFTWARE\BlackBerry\BlackBerryVSPlugin@NDKHostPath)</QNX_HOST>
-    <from_file>$([System.IO.File]::ReadAllText("$(QNX_HOST)\etc\qcc\gcc\default").Substring(4,5))</from_file>
+    <from_file Condition="'$(QNX_HOST)' != ''">$([System.IO.File]::ReadAllText("$(QNX_HOST)\etc\qcc\gcc\default").Substring(4,5))</from_file>
     <QCC_CONF_PATH Condition="'$(QCC_CONF_PATH)' == ''">$(QNX_HOST)\etc\qcc\gcc</QCC_CONF_PATH>
     <CPUVARDIR>armle-v7</CPUVARDIR>
     <CompilerVersion>$(from_file)</CompilerVersion>

--- a/src/VSNDK.Tasks/BlackBerrySimulator/PlatformToolsets/qcc/Microsoft.Cpp.BlackBerrySimulator.qcc.props
+++ b/src/VSNDK.Tasks/BlackBerrySimulator/PlatformToolsets/qcc/Microsoft.Cpp.BlackBerrySimulator.qcc.props
@@ -17,7 +17,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <PropertyGroup>
     <QNX_TARGET>$(Registry:HKEY_CURRENT_USER\SOFTWARE\BlackBerry\BlackBerryVSPlugin@NDKTargetPath)</QNX_TARGET>
     <QNX_HOST>$(Registry:HKEY_CURRENT_USER\SOFTWARE\BlackBerry\BlackBerryVSPlugin@NDKHostPath)</QNX_HOST>
-    <from_file>$([System.IO.File]::ReadAllText("$(QNX_HOST)\etc\qcc\gcc\default").Substring(4,5))</from_file>
+    <from_file Condition="'$(QNX_HOST)' != ''">$([System.IO.File]::ReadAllText("$(QNX_HOST)\etc\qcc\gcc\default").Substring(4,5))</from_file>
     <QCC_CONF_PATH Condition="'$(QCC_CONF_PATH)' == ''">$(QNX_HOST)\etc\qcc\gcc</QCC_CONF_PATH>
     <CPUVARDIR>x86</CPUVARDIR>
     <CompilerVersion>$(from_file)</CompilerVersion>

--- a/src_vs2012/VSNDK.Package/ViewModel.cs
+++ b/src_vs2012/VSNDK.Package/ViewModel.cs
@@ -485,17 +485,26 @@ namespace RIM.VSNDK_Package
             return retVal;
         }
 
+        /// <summary>
+        /// Load the permissions list
+        /// </summary>
         private void LoadPermissions()
         {
             SettingsData settingsData = new SettingsData();
+            bool oldListMethod = true;
+            XmlNodeList pList = null;
 
-            XmlDocument xmlDoc = new XmlDocument();
-            xmlDoc.Load(settingsData.TargetPath + @"\..\blackberry-sdk-descriptor.xml");
-            XmlNodeList pList = xmlDoc.GetElementsByTagName("permission");
+            if (settingsData.TargetPath != "")
+            {
+                XmlDocument xmlDoc = new XmlDocument();
+                xmlDoc.Load(settingsData.TargetPath + @"\..\blackberry-sdk-descriptor.xml");
+                pList = xmlDoc.GetElementsByTagName("permission");
+                oldListMethod = false;
+            }
 
             IList<PermissionItemClass> PermissionList = new List<PermissionItemClass>();
 
-            if (pList.Count == 0) // Old Listing Method
+            if (oldListMethod) // Old Listing Method
             {
                 PermissionItemClass permissionItem = new PermissionItemClass(isPermissionChecked("bbm_connect"), "BlackBerry Messenger", "bbm_connect", getPermissionIcon("bbm_connect"));
                 PermissionList.Add(permissionItem);

--- a/src_vs2012/VSNDK.Tasks/BlackBerry/PlatformToolsets/qcc/Microsoft.Cpp.BlackBerry.qcc.props
+++ b/src_vs2012/VSNDK.Tasks/BlackBerry/PlatformToolsets/qcc/Microsoft.Cpp.BlackBerry.qcc.props
@@ -17,7 +17,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <PropertyGroup>
     <QNX_TARGET>$(Registry:HKEY_CURRENT_USER\SOFTWARE\BlackBerry\BlackBerryVSPlugin@NDKTargetPath)</QNX_TARGET>
     <QNX_HOST>$(Registry:HKEY_CURRENT_USER\SOFTWARE\BlackBerry\BlackBerryVSPlugin@NDKHostPath)</QNX_HOST>
-    <from_file>$([System.IO.File]::ReadAllText("$(QNX_HOST)\etc\qcc\gcc\default").Substring(4,5))</from_file>
+    <from_file Condition="'$(QNX_HOST)' != ''">$([System.IO.File]::ReadAllText("$(QNX_HOST)\etc\qcc\gcc\default").Substring(4,5))</from_file>
     <QCC_CONF_PATH Condition="'$(QCC_CONF_PATH)' == ''">$(QNX_HOST)\etc\qcc\gcc</QCC_CONF_PATH>
     <CPUVARDIR>armle-v7</CPUVARDIR>
     <CompilerVersion>$(from_file)</CompilerVersion>

--- a/src_vs2012/VSNDK.Tasks/BlackBerrySimulator/PlatformToolsets/qcc/Microsoft.Cpp.BlackBerrySimulator.qcc.props
+++ b/src_vs2012/VSNDK.Tasks/BlackBerrySimulator/PlatformToolsets/qcc/Microsoft.Cpp.BlackBerrySimulator.qcc.props
@@ -17,7 +17,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <PropertyGroup>
     <QNX_TARGET>$(Registry:HKEY_CURRENT_USER\SOFTWARE\BlackBerry\BlackBerryVSPlugin@NDKTargetPath)</QNX_TARGET>
     <QNX_HOST>$(Registry:HKEY_CURRENT_USER\SOFTWARE\BlackBerry\BlackBerryVSPlugin@NDKHostPath)</QNX_HOST>
-    <from_file>$([System.IO.File]::ReadAllText("$(QNX_HOST)\etc\qcc\gcc\default").Substring(4,5))</from_file>
+    <from_file Condition="'$(QNX_HOST)' != ''">$([System.IO.File]::ReadAllText("$(QNX_HOST)\etc\qcc\gcc\default").Substring(4,5))</from_file>
     <QCC_CONF_PATH Condition="'$(QCC_CONF_PATH)' == ''">$(QNX_HOST)\etc\qcc\gcc</QCC_CONF_PATH>
     <CPUVARDIR>x86</CPUVARDIR>
     <CompilerVersion>$(from_file)</CompilerVersion>


### PR DESCRIPTION
- Project properties pages will now open even if the API level is not installed.
- bar-descriptor.xml will not open even if the API level is not installed.
